### PR TITLE
[WIP] Updates to how you create migrations, middleware auto injected, folde…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to `request-migrations` will be documented in this file
 
+## 0.2.0 - 2017-08-30
+- Pinning API Versions for a user
+- Caching Request Migrations
+- Allowing for providing full path urls to allow usage of route helpers
+- Migration Command updated to be interactive
+- Migrations now use a convention for storing migrations
+    \App\Http\Migrations\Version_YYYY_MM_DD
+
 ## 0.1.0 - 2017-08-16
 
 - initial release

--- a/README.md
+++ b/README.md
@@ -23,6 +23,19 @@ This package supports Laravel 5.5 autoloading. If you are using an earlier versi
 \TomSchlick\RequestMigrations\RequestMigrationsMiddleware::class,
 ```
 
+### Middleware
+
+Add the middleware to your Http Kernel `app/Http/Kernel.php`.
+
+```php
+protected $middlewareGroups = [
+        'api' => [
+            '....',
+	        \TomSchlick\RequestMigrations\RequestMigrationsMiddleware::class,
+        ];
+];
+```
+
 ### Configuration
 
 Run the following Artisan command to publish the package configuration to `config/request-migrations.php`.

--- a/README.md
+++ b/README.md
@@ -23,17 +23,6 @@ This package supports Laravel 5.5 autoloading. If you are using an earlier versi
 \TomSchlick\RequestMigrations\RequestMigrationsMiddleware::class,
 ```
 
-### Middleware
-
-Add the middleware to your Http Kernel `app/Http/Kernel.php`.
-
-```php
-protected $middleware = [
-	\TomSchlick\RequestMigrations\RequestMigrationsMiddleware::class,
-];
-
-```
-
 ### Configuration
 
 Run the following Artisan command to publish the package configuration to `config/request-migrations.php`.
@@ -53,7 +42,7 @@ php artisan make:request-migration ExampleMigration
 
 ```
 
-The command will generate a request migration and publish it to `App/Http/Migrations/*`.
+The command will generate a request migration and publish it to `App/Http/Migrations/Version_YYYY_MM_DD/*`.
 
 ## Changelog
 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,16 @@ You can generate a new request migration using the Artisan CLI.
 php artisan make:request-migration ExampleMigration
 
 ```
-
 The command will generate a request migration and publish it to `App/Http/Migrations/Version_YYYY_MM_DD/*`.
+
+### Caching Migrations
+
+Once you move to prod you should cache the results
+
+```shell
+php artisan cache:request-migrations
+
+```
 
 ## Changelog
 

--- a/config/config.php
+++ b/config/config.php
@@ -22,7 +22,8 @@ return [
     | Current Version
     |--------------------------------------------------------------------------
     |
-    | This is the version users will be defaulted to
+    | This is the version users will be defaulted to. If you do not set
+    | a version the latest version will be used.
     |
     */
 

--- a/config/config.php
+++ b/config/config.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+
     'headers'         => [
         'current-version'  => 'x-api-current-version',
         'request-version'  => 'x-api-request-version',

--- a/config/config.php
+++ b/config/config.php
@@ -9,9 +9,4 @@ return [
 
     'current_version' => '',
 
-    'versions' => [
-        'YYYY-MM-DD' => [
-            // \App\Http\Migrations\ExampleChangeFieldName::class
-        ],
-    ],
 ];

--- a/config/config.php
+++ b/config/config.php
@@ -2,11 +2,29 @@
 
 return [
 
-    'headers'         => [
+    /*
+    |--------------------------------------------------------------------------
+    | Headers
+    |--------------------------------------------------------------------------
+    |
+    | You can customize your headers that you want to send in with each request
+    |
+    */
+
+    'headers' => [
         'current-version'  => 'x-api-current-version',
         'request-version'  => 'x-api-request-version',
         'response-version' => 'x-api-response-version',
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Current Version
+    |--------------------------------------------------------------------------
+    |
+    | This is the version users will be defaulted to
+    |
+    */
 
     'current_version' => '',
 

--- a/src/Commands/CacheRequestMigrationsCommand.php
+++ b/src/Commands/CacheRequestMigrationsCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace TomSchlick\RequestMigrations\Commands;
+
+use function base_path;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use TomSchlick\RequestMigrations\RequestMigrationsServiceProvider;
+
+class CacheRequestMigrationsCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'cache:request-migrations';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Caches the request migrations for production';
+
+    /**
+     * Execute the console command.
+     *
+     * @return bool|null
+     */
+    public function handle()
+    {
+        $requestMigrationsCache = RequestMigrationsServiceProvider::REQUEST_MIGRATIONS_CACHE;
+        
+        File::delete($requestMigrationsCache);
+            
+        File::put(
+            base_path($requestMigrationsCache),
+            '<?php return '.var_export(app()->make('getRequestMigrationsVersions')->toArray(), true).';'
+        );
+        
+        $this->info('Request Migrations Cached');
+    }
+}

--- a/src/Commands/RequestMigrationMakeCommand.php
+++ b/src/Commands/RequestMigrationMakeCommand.php
@@ -2,10 +2,14 @@
 
 namespace TomSchlick\RequestMigrations\Commands;
 
+use Carbon\Carbon;
 use Illuminate\Console\GeneratorCommand;
 
 class RequestMigrationMakeCommand extends GeneratorCommand
 {
+    protected $version;
+    protected $versions;
+
     /**
      * The console command name.
      *
@@ -27,7 +31,35 @@ class RequestMigrationMakeCommand extends GeneratorCommand
      */
     public function handle()
     {
+        $this->versions = app()->make('getRequestMigrationsVersions');
+
+        $this->version = $this->choice(
+            "Which version would you like to publish to?",
+            $choices = $this->publishableChoices()
+        );
+
+        if ($this->version == $choices[0]) {
+            $this->version = $this->ask('Please enter your version in Y-m-d format.', Carbon::now()->format('Y-m-d'));
+        }
+
+        if(empty(config('request-migrations.current_version'))) {
+            $this->info('Please set your default version in your request-migrations config');
+        }
+
         parent::handle();
+    }
+
+    /**
+     * The choices available via the prompt.
+     *
+     * @return array
+     */
+    protected function publishableChoices()
+    {
+        return array_merge(
+            ['<comment>Create New Version</comment>'],
+            $this->versions->toArray()
+        );
     }
 
     /**
@@ -49,6 +81,6 @@ class RequestMigrationMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace . '\Http\Migrations';
+        return $rootNamespace . '\http\Migrations\Version_'.str_replace('-', '_', $this->version);
     }
 }

--- a/src/Commands/RequestMigrationMakeCommand.php
+++ b/src/Commands/RequestMigrationMakeCommand.php
@@ -47,7 +47,7 @@ class RequestMigrationMakeCommand extends GeneratorCommand
         }
 
 
-        if (!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/",$this->version)) {
+        if (!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/",str_replace('_', '-', $this->version))) {
             return $this->error('You provided a invalid date');
         }
 

--- a/src/Commands/RequestMigrationMakeCommand.php
+++ b/src/Commands/RequestMigrationMakeCommand.php
@@ -3,7 +3,9 @@
 namespace TomSchlick\RequestMigrations\Commands;
 
 use Carbon\Carbon;
+use Illuminate\Support\Facades\File;
 use Illuminate\Console\GeneratorCommand;
+use TomSchlick\RequestMigrations\RequestMigrationsServiceProvider;
 
 class RequestMigrationMakeCommand extends GeneratorCommand
 {
@@ -31,7 +33,9 @@ class RequestMigrationMakeCommand extends GeneratorCommand
      */
     public function handle()
     {
-        $this->versions = app()->make('getRequestMigrationsVersions');
+        File::delete(RequestMigrationsServiceProvider::REQUEST_MIGRATIONS_CACHE);
+
+        $this->versions = app()->make('getRequestMigrationsVersions')->keys();
 
         $this->version = $this->choice(
             "Which version would you like to publish to?",
@@ -47,7 +51,8 @@ class RequestMigrationMakeCommand extends GeneratorCommand
         }
 
         if (!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/",str_replace('_', '-', $this->version))) {
-            return $this->error('You provided a invalid date');
+            $this->error('You provided a invalid date');
+            return false;
         }
 
         parent::handle();
@@ -60,10 +65,13 @@ class RequestMigrationMakeCommand extends GeneratorCommand
      */
     protected function publishableChoices()
     {
-        return array_merge(
-            ['<comment>Create New Version</comment>'],
-            $this->versions->toArray()
-        );
+        if($this->versions) {
+            return array_merge(
+                ['<comment>Create New Version</comment>'],
+                $this->versions->toArray()
+            );
+        }
+
     }
 
     /**

--- a/src/Commands/RequestMigrationMakeCommand.php
+++ b/src/Commands/RequestMigrationMakeCommand.php
@@ -86,6 +86,6 @@ class RequestMigrationMakeCommand extends GeneratorCommand
      */
     protected function getDefaultNamespace($rootNamespace)
     {
-        return $rootNamespace . '\http\Migrations\Version_'.str_replace('-', '_', $this->version);
+        return $rootNamespace . '\Http\Migrations\Version_'.str_replace('-', '_', $this->version);
     }
 }

--- a/src/Commands/RequestMigrationMakeCommand.php
+++ b/src/Commands/RequestMigrationMakeCommand.php
@@ -46,7 +46,6 @@ class RequestMigrationMakeCommand extends GeneratorCommand
             $this->info('Please set your default version in your request-migrations config');
         }
 
-
         if (!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/",str_replace('_', '-', $this->version))) {
             return $this->error('You provided a invalid date');
         }

--- a/src/Commands/RequestMigrationMakeCommand.php
+++ b/src/Commands/RequestMigrationMakeCommand.php
@@ -46,6 +46,11 @@ class RequestMigrationMakeCommand extends GeneratorCommand
             $this->info('Please set your default version in your request-migrations config');
         }
 
+
+        if (!preg_match("/^[0-9]{4}-(0[1-9]|1[0-2])-(0[1-9]|[1-2][0-9]|3[0-1])$/",$this->version)) {
+            return $this->error('You provided a invalid date');
+        }
+
         parent::handle();
     }
 

--- a/src/Database/Migrations/add_api_version_to_users_table.php.stub
+++ b/src/Database/Migrations/add_api_version_to_users_table.php.stub
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddApiVersionToUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (!(Schema::hasColumn('users', 'api_version'))) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->string('api_version')->nullable()->default(null);
+            });
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        if ((Schema::hasColumn('users', 'api_version'))) {
+            Schema::table('users', function (Blueprint $table) {
+                $table->dropColumn('api_version');
+            });
+        }
+    }
+}

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -106,7 +106,7 @@ class Migrator
     /**
      * Figure out which migrations apply to the current request.
      *
-     * @param $migrationVersion The migration version to check migrations against
+     * @param $migrationVersion string The migration version to check migrations against
      *
      * @return array
      */

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -19,6 +19,8 @@ class Migrator
      */
     protected $response;
 
+    protected $versions;
+
     protected $currentVersion = null;
 
     protected $requestVersion = null;
@@ -41,7 +43,12 @@ class Migrator
         $this->request = $request;
         $this->config = $config;
 
+        $this->versions = app()->make('getRequestMigrationsVersions');
+
         $this->currentVersion = Arr::get($config, 'current_version');
+        if(empty($this->currentVersion)) {
+            $this->currentVersion = $this->versions->keys()->first();
+        }
         $this->requestVersion = $request->header(Arr::get($config, 'headers.request-version'));
         $this->responseVersion = $request->header(Arr::get($config, 'headers.response-version'));
     }
@@ -120,9 +127,7 @@ class Migrator
      */
     public function neededMigrations($migrationVersion) : array
     {
-        return Collection::make(
-                app()->make('getRequestMigrationsVersions')
-            )
+        return $this->versions
             ->reject(function ($classList, $version) use ($migrationVersion) {
                 return $version <= $migrationVersion;
             })

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -69,6 +69,8 @@ class Migrator
      * Process the migrations for the outgoing response.
      *
      * @param \Symfony\Component\HttpFoundation\Response $response
+     *
+     * @return $this
      */
     public function processResponseMigrations(Response $response)
     {
@@ -83,16 +85,22 @@ class Migrator
             ->each(function ($migration) {
                 $this->response = (new $migration())->migrateResponse($this->response);
             });
+
+        return $this;
     }
 
     /**
      * Set the API Response Headers.
+     * 
+     * @return $this
      */
     public function setResponseHeaders()
     {
         $this->response->headers->set(Arr::get($this->config, 'headers.current-version'), $this->currentVersion, true);
         $this->response->headers->set(Arr::get($this->config, 'headers.request-version'), $this->requestVersion, true);
         $this->response->headers->set(Arr::get($this->config, 'headers.response-version'), $this->responseVersion, true);
+
+        return $this;
     }
 
     /**

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -46,9 +46,11 @@ class Migrator
         $this->versions = app()->make('getRequestMigrationsVersions');
 
         $this->currentVersion = Arr::get($config, 'current_version');
+
         if(empty($this->currentVersion)) {
             $this->currentVersion = $this->versions->keys()->first();
         }
+
         $this->requestVersion = $request->header(Arr::get($config, 'headers.request-version'));
         $this->responseVersion = $request->header(Arr::get($config, 'headers.response-version'));
     }
@@ -127,9 +129,13 @@ class Migrator
      */
     public function neededMigrations($migrationVersion) : array
     {
+        if(empty($migrationVersion)) {
+            return [];
+        }
+
         return $this->versions
             ->reject(function ($classList, $version) use ($migrationVersion) {
-                return $version <= $migrationVersion;
+                return $version < $migrationVersion;
             })
             ->filter(function ($classList) {
                 return Collection::make($classList)->transform(function ($class) {

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -112,13 +112,14 @@ class Migrator
      */
     public function neededMigrations($migrationVersion) : array
     {
-        return Collection::make(Arr::get($this->config, 'versions', []))
-            ->reject(function ($classList, $version) use ($migrationVersion) {
+        return Collection::make(
+                app()->make('getRequestMigrationsVersions')
+            )->reject(function ($classList, $version) use ($migrationVersion) {
                 return $version <= $migrationVersion;
             })->filter(function ($classList) {
                 return Collection::make($classList)->transform(function ($class) {
                     return Collection::make((new $class)->paths())->filter(function ($path) {
-                        return $this->request->is($path);
+                        return $this->request->fullUrlIs($path);
                     });
                 })->isNotEmpty();
             })->toArray();

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -91,7 +91,7 @@ class Migrator
 
     /**
      * Set the API Response Headers.
-     * 
+     *
      * @return $this
      */
     public function setResponseHeaders()
@@ -122,9 +122,11 @@ class Migrator
     {
         return Collection::make(
                 app()->make('getRequestMigrationsVersions')
-            )->reject(function ($classList, $version) use ($migrationVersion) {
+            )
+            ->reject(function ($classList, $version) use ($migrationVersion) {
                 return $version <= $migrationVersion;
-            })->filter(function ($classList) {
+            })
+            ->filter(function ($classList) {
                 return Collection::make($classList)->transform(function ($class) {
                     return Collection::make((new $class)->paths())->filter(function ($path) {
                         return $this->request->fullUrlIs($path);

--- a/src/RequestMigrationsMiddleware.php
+++ b/src/RequestMigrationsMiddleware.php
@@ -14,6 +14,7 @@ class RequestMigrationsMiddleware
      * @var \Illuminate\Http\Request
      */
     protected $request;
+    protected $versions;
 
     /**
      * @param \Illuminate\Http\Request $request
@@ -32,6 +33,7 @@ class RequestMigrationsMiddleware
 
         $requestVersion = $this->requestVersion();
         $responseVersion = $this->responseVersion();
+
 
         if ($requestVersion && ! array_key_exists($requestVersion, $this->versions())) {
             throw new HttpException(400, 'The request version is invalid');
@@ -57,7 +59,11 @@ class RequestMigrationsMiddleware
      */
     private function versions() : array
     {
-        return app()->make('getRequestMigrationsVersions')->toArray();
+        if($this->versions) {
+            return $this->versions;
+        }
+
+        return $this->versions = app()->make('getRequestMigrationsVersions')->toArray();
     }
 
     /**

--- a/src/RequestMigrationsMiddleware.php
+++ b/src/RequestMigrationsMiddleware.php
@@ -44,7 +44,7 @@ class RequestMigrationsMiddleware
      */
     private function versions() : array
     {
-        return array_keys(Config::get('request-migrations.versions'));
+        return app()->make('getRequestMigrationsVersions')->toArray();
     }
 
     /**

--- a/src/RequestMigrationsMiddleware.php
+++ b/src/RequestMigrationsMiddleware.php
@@ -45,7 +45,8 @@ class RequestMigrationsMiddleware
 
         return $migrator->processResponseMigrations(
                 $next($migrator->processRequestMigrations())
-            )->setResponseHeaders()
+            )
+            ->setResponseHeaders()
             ->getResponse();
     }
 

--- a/src/RequestMigrationsMiddleware.php
+++ b/src/RequestMigrationsMiddleware.php
@@ -43,13 +43,10 @@ class RequestMigrationsMiddleware
 
         $migrator = new Migrator($request, config('request-migrations'));
 
-        $migrator->processResponseMigrations(
-            $next($migrator->processRequestMigrations())
-        );
-
-        $migrator->setResponseHeaders();
-
-        return $migrator->getResponse();
+        return $migrator->processResponseMigrations(
+                $next($migrator->processRequestMigrations())
+            )->setResponseHeaders()
+            ->getResponse();
     }
 
     /**

--- a/src/RequestMigrationsServiceProvider.php
+++ b/src/RequestMigrationsServiceProvider.php
@@ -5,8 +5,8 @@ namespace TomSchlick\RequestMigrations;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider;
-use TomSchlick\RequestMigrations\Commands\CacheRequestMigrationsCommand;
 use TomSchlick\RequestMigrations\Commands\RequestMigrationMakeCommand;
+use TomSchlick\RequestMigrations\Commands\CacheRequestMigrationsCommand;
 
 class RequestMigrationsServiceProvider extends ServiceProvider
 {

--- a/src/RequestMigrationsServiceProvider.php
+++ b/src/RequestMigrationsServiceProvider.php
@@ -33,9 +33,16 @@ class RequestMigrationsServiceProvider extends ServiceProvider
         $this->commands([RequestMigrationMakeCommand::class]);
 
         $this->app->bind('getRequestMigrationsVersions', function() {
-            return collect(File::directories(app_path('Http/Migrations')))->map(function($versionDirectory) {
-                return substr($versionDirectory, strpos($versionDirectory, 'Version_') + 8);
-            });
+
+            $migrationsPath = app_path('Http/Migrations');
+
+            if(File::exists($migrationsPath)) {
+                return collect(File::directories($migrationsPath))->map(function($versionDirectory) {
+                    return substr($versionDirectory, strpos($versionDirectory, 'Version_') + 8);
+                });
+            }
+
+            return collect();
         });
     }
 }

--- a/src/RequestMigrationsServiceProvider.php
+++ b/src/RequestMigrationsServiceProvider.php
@@ -5,6 +5,7 @@ namespace TomSchlick\RequestMigrations;
 use Illuminate\Support\Facades\File;
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Support\ServiceProvider;
+use Symfony\Component\Finder\SplFileInfo;
 use TomSchlick\RequestMigrations\Commands\RequestMigrationMakeCommand;
 
 class RequestMigrationsServiceProvider extends ServiceProvider
@@ -39,6 +40,13 @@ class RequestMigrationsServiceProvider extends ServiceProvider
             if(File::exists($migrationsPath)) {
                 return collect(File::directories($migrationsPath))->map(function($versionDirectory) {
                     return substr($versionDirectory, strpos($versionDirectory, 'Version_') + 8);
+                })->flip()->map(function($value, $key) use($migrationsPath) {
+                    $files = collect();
+                    /** @var SplFileInfo $file */
+                    foreach(File::files($migrationsPath.'/Version_'.$key) as $file) {
+                        $files->push(app()->getNamespace().'Http\Migrations\Version_'.$key.'\\'.$file->getBasename('.php'));
+                    }
+                    return $files;
                 });
             }
 

--- a/src/RequestMigrationsServiceProvider.php
+++ b/src/RequestMigrationsServiceProvider.php
@@ -46,7 +46,7 @@ class RequestMigrationsServiceProvider extends ServiceProvider
             $cacheFile = base_path(self::REQUEST_MIGRATIONS_CACHE);
 
             if(File::exists($cacheFile)) {
-                return collect(require_once($cacheFile));
+                return collect(require($cacheFile));
             }
 
             return $this->generateRequestMigrations();


### PR DESCRIPTION
This is WIP

Ideas : 

- [x] Column set on user to define what version of api to use
- [x] Cache versions when using php artisan cache , or cache right away?
- [x] Migrations command interactive to choose version and create versions
- [x] Provide Full path instead of just paths , allows usage to use route helpers
- [ ] API Versioning , if releasing a new major version these migrations will be invalid 


![image](https://user-images.githubusercontent.com/2066668/29880155-11d3b06a-8d75-11e7-92bf-0507691e055d.png)

![image](https://user-images.githubusercontent.com/2066668/29880168-1c3052e8-8d75-11e7-9029-4188e073334e.png)


Let me know on your thoughts~
