### PR TITLE
Update Travis and Laravel Events

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,78 @@
-language: php
-
-php:
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-
-sudo: false
-
 cache:
   directories:
     - $HOME/.composer/cache
 
+language: php
+
+env:
+  global:
+    - COVERAGE=0
+
+matrix:
+  include:
+    - php: 7.1
+      env: LARAVEL='5.4.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.1
+      env: LARAVEL='5.4.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.1
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.1
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.1
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.1
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.1
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.1
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.1
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.1
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.2
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.2
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.6.*' TESTBENCH='3.6.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.7.*' TESTBENCH='3.7.*' COMPOSER_FLAGS='--prefer-stable'
+    - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-lowest'
+    - php: 7.3
+      env: LARAVEL='5.8.*' TESTBENCH='3.8.*' COMPOSER_FLAGS='--prefer-stable'
+  fast_finish: true
+
 before_script:
+    - composer config discard-changes true
+
+before_install:
   - travis_retry composer self-update
-  - travis_retry composer update --no-interaction --prefer-dist
+  - travis_retry composer require "laravel/framework:${LARAVEL}" "orchestra/testbench:${TESTBENCH}" --no-interaction --no-update
+
+install:
+  - travis_retry composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction --no-suggest
 
 script:
   - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,10 +11,6 @@ env:
 matrix:
   include:
     - php: 7.1
-      env: LARAVEL='5.4.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
-    - php: 7.1
-      env: LARAVEL='5.4.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'
-    - php: 7.1
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-lowest'
     - php: 7.1
       env: LARAVEL='5.5.*' TESTBENCH='3.5.*' COMPOSER_FLAGS='--prefer-stable'

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         }
     ],
     "require" : {
-        "php" : "^7.0",
+        "php" : "^7.1",
         "illuminate/config" : "^5.4",
         "illuminate/contracts" : "^5.4",
         "illuminate/events" : "^5.4",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/support" : "^5.5"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "^7.0",
+        "phpunit/phpunit" : "^6.0|^7.0",
         "orchestra/testbench" : "~3.5",
         "mockery/mockery": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
     ],
     "require" : {
         "php" : "^7.1",
-        "illuminate/config" : "^5.4",
-        "illuminate/contracts" : "^5.4",
-        "illuminate/events" : "^5.4",
-        "illuminate/http" : "^5.4",
-        "illuminate/support" : "^5.4"
+        "illuminate/config" : "^5.5",
+        "illuminate/contracts" : "^5.5",
+        "illuminate/events" : "^5.5",
+        "illuminate/http" : "^5.5",
+        "illuminate/support" : "^5.5"
     },
     "require-dev" : {
-        "phpunit/phpunit" : "^6.0",
+        "phpunit/phpunit" : "^7.0",
         "orchestra/testbench" : "~3.5",
-        "mockery/mockery": "^0.9.5"
+        "mockery/mockery": "^1.0"
     },
     "autoload" : {
         "psr-4" : {

--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -118,11 +118,11 @@ class Migrator
                 $class = new $migration();
                 $originalRequest = $this->request;
 
-                Event::fire(new RequestIsMigrating($class, $originalRequest));
+                Event::dispatch(new RequestIsMigrating($class, $originalRequest));
 
                 $this->request = $class->migrateRequest($originalRequest);
 
-                Event::fire(new RequestHasMigrated($class, $originalRequest, $this->request));
+                Event::dispatch(new RequestHasMigrated($class, $originalRequest, $this->request));
             });
 
         return $this->request;
@@ -147,11 +147,11 @@ class Migrator
                 $class = new $migration();
                 $originalResponse = $this->response;
 
-                Event::fire(new ResponseIsMigrating($class, $originalResponse));
+                Event::dispatch(new ResponseIsMigrating($class, $originalResponse));
 
                 $this->response = $class->migrateResponse($originalResponse);
 
-                Event::fire(new ResponseHasMigrated($class, $originalResponse, $this->response));
+                Event::dispatch(new ResponseHasMigrated($class, $originalResponse, $this->response));
             });
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,7 +16,7 @@ use TomSchlick\RequestMigrations\Tests\Migrations\PostTitleMigration;
 
 abstract class TestCase extends Orchestra
 {
-    public function setUp()
+    public function setUp() : void
     {
         parent::setUp();
         $this->setupConfig($this->app);


### PR DESCRIPTION
- Updates Travis CI to test multiple versions of laravel to catch specific version compat
- Updates `Event::fire` to `Event::dispatch` as it was removed in Laravel 5.8
- Updates Composer minimum PHP to 7.1 ***BREAKING CHANGE***
- Drops Laravel 5.4 support ***BREAKING CHANGE***