### PR TITLE
Use the request->is() helper for more flexibility

### DIFF
--- a/src/Migrator.php
+++ b/src/Migrator.php
@@ -201,7 +201,7 @@ class Migrator
     private function migrationsForVersion(array $migrationClasses) : Collection
     {
         return Collection::make($migrationClasses)->filter(function ($migrationClass) {
-            return in_array($this->request->path(), (new $migrationClass)->paths());
+            return $this->request->is((new $migrationClass)->paths());
         });
     }
 


### PR DESCRIPTION
Using the request->is() helper allows for additonal functionality in
request pattern matching rather than having to always apply an explicit
path.